### PR TITLE
Resolve earlycon defined twice in bootargs

### DIFF
--- a/include/configs/ls1046accx.h
+++ b/include/configs/ls1046accx.h
@@ -93,7 +93,7 @@
 	"crypto_key_kernel=\0" \
 	"crypto_key_dtb=\0" \
 	"hwconfig=fsl_ddr:bank_intlv=auto\0" \
-	"bootargs=earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 ccx.firmware=" CCX_FIRMWARE_API_VERSION "\0"\
+	"bootargs=ccx.firmware=" CCX_FIRMWARE_API_VERSION "\0"\
 	"bootargs_enable_loader=setenv bootargs ${bootargs} loader\0" \
 	"bootargs_set_rootfs=setenv bootargs ${bootargs} root=/dev/sda${bootarg_rootpart} ro\0" \
 	"bootargs_set_console=setenv bootargs ${bootargs} console=ttyS0,${baudrate} earlycon=uart8250,mmio,0x21c0500\0" \


### PR DESCRIPTION
This PR fixes a bug with earlycon being defined twice in bootargs for LS1046ACCX board.

The root cause of the issue is with the environment variable being evaluated inside another variable. Both variables contain earlycon definitions resulting in earlycon being defined twice during evaluation.

The variable that is being evaluated is `bootargs`. It is evaluated inside  `bootargs_set_console` environment variable. The issue will occur every time `bootargs_set_console` is used.

Given that there is environment variable, `bootargs_set_console`, dedicated for setting console parameters, it makes sense to keep those parameters in that variable (i.e. where the console to be used is being defined).