### PR TITLE
Add support for programming MAC address 5 and MAC address 6

### DIFF
--- a/include/configs/ls1046accx.h
+++ b/include/configs/ls1046accx.h
@@ -233,7 +233,9 @@
 		"askenv eth1addr \"Enter MAC Address 2 [xx:xx:xx:xx:xx:xx], ie. 84:8B:CD:20:00:C9 => \" 17 && " \
 		"askenv eth2addr \"Enter MAC Address 3 [xx:xx:xx:xx:xx:xx], ie. 84:8B:CD:20:00:CA => \" 17 && " \
 		"askenv eth3addr \"Enter MAC Address 4 [xx:xx:xx:xx:xx:xx], ie. 84:8B:CD:20:00:CB => \" 17 && " \
-		"env export -t ${loadaddr_ram_dec} serialnum ethaddr eth1addr eth2addr eth3addr && " \
+		"askenv eth4addr \"Enter MAC Address 5 [xx:xx:xx:xx:xx:xx], ie. 84:8B:CD:20:00:CD (Press Return if N/A) => \" 17 && " \
+		"askenv eth5addr \"Enter MAC Address 6 [xx:xx:xx:xx:xx:xx], ie. 84:8B:CD:20:00:CE (Press Return if N/A) => \" 17 && " \
+		"env export -t ${loadaddr_ram_dec} serialnum ethaddr eth1addr eth2addr eth3addr eth4addr eth5addr && " \
 		"setenv filesize 0x3d0 && " \
 		"run crypto_encrypt && " \
 		"setenv loadaddr_ram ${loadaddr_ram_enc} && " \
@@ -245,7 +247,7 @@
 		"setenv filesize 0x400 && " \
 		"run flash_to_ram && " \
 		"run crypto_decrypt && " \
-		"env import -t ${loadaddr_ram_dec} ${filesize} serialnum ethaddr eth1addr eth2addr eth3addr\0" \
+		"env import -t ${loadaddr_ram_dec} ${filesize} serialnum ethaddr eth1addr eth2addr eth3addr eth4addr eth5addr\0" \
 	"system_load=" \
 		"run system_set_ids && " \
 		"if run sdcard_to_flash_pbl && run sdcard_to_flash_fib; then " \


### PR DESCRIPTION
### Description
This PR adds support for programming MAC address 5 and MAC address 6 on LS1046ACCX board.

Introduced two new environment variables for fifth (`eth4addr`) and sixth (`eth5addr`) Ethernet interfaces.
The user repeatedly receives a prompt to input MAC Address (from 1 to 6). The user is also reminded that, if MAC Addresses 5 and 6 are unavailable on the device, they can press return so that those addresses do not get programmed.

### Testing

- verified values of environment variables being set using `printenv` command
- verified variables not getting defined when hitting return on `askenv` prompt
- verified environment variables being exported to memory address by reading memory contents using `md` command (for both cases - when there is 4 MAC Addresses on the system and 6 MAC Addresses)
- verified environment variables being imported from memory address by rebooting the board and running `import` command (for both cases - when there is 4 MAC Addresses on the system and 6 MAC Addresses)

### Other considerations
This PR provides easiest and simplest solution without introduced complexity.

Other considerations included taking a variable for the number of Ethernet devices on the system and dynamically prompting the user for input depending on the value of such variable. Implementing a counter like this with no loop functionality would introduce too much complexity to the script and make its style inconsistent and difficult to read.

Prompting the user to input the first MAC Address, so that the system will define the remaining MAC Address, is unrealistic without increasing complexity of the script even further. The last byte will have to be checked for overflow when incrementing and bytes will somehow have to be parsed into hexadecimal numbers. Multiple other comparisons will also have to be performed. 

Another option was to hardcode the first three bytes of MAC Address (since they are common) and prompt the user for the remaining three bytes for each MAC Address. However, it couldn't be done without introducing complexity and multiple `if` statements in the config script.
