### PR TITLE
SYSTEMX_LOADER is not related to FSL_LS_PPA

### DIFF
--- a/board/freescale/ls1046accx/Kconfig
+++ b/board/freescale/ls1046accx/Kconfig
@@ -13,12 +13,6 @@ config SYS_SOC
 config SYS_CONFIG_NAME
 	default "ls1046accx"
 
-if FSL_LS_PPA
-config SYS_LS_PPA_FW_ADDR
-	hex "PPA Firmware Addr"
-	default 0x40400000 if SYS_LS_PPA_FW_IN_XIP && QSPI_BOOT
-	default 0x400000 if SYS_LS_PPA_FW_IN_MMC || SYS_LS_PPA_FW_IN_NAND
-
 choice SYSTEMX_LOADER
 	prompt "SystemX Loader Srcipt"
 	default SYSTEMX_LOADER_BOOT
@@ -31,6 +25,12 @@ choice SYSTEMX_LOADER
 	config SYSTEMX_LOADER_NONE
 		bool "Don't boot a kernel"
 endchoice
+
+if FSL_LS_PPA
+config SYS_LS_PPA_FW_ADDR
+	hex "PPA Firmware Addr"
+	default 0x40400000 if SYS_LS_PPA_FW_IN_XIP && QSPI_BOOT
+	default 0x400000 if SYS_LS_PPA_FW_IN_MMC || SYS_LS_PPA_FW_IN_NAND
 
 if CHAIN_OF_TRUST
 config SYS_LS_PPA_ESBC_ADDR


### PR DESCRIPTION
SYSTEMX_LOADER choice was under if FSL_LS_PPA

when building from the github repo, SYSTEMX_LOADER_LOAD was being set because we don't set FSL_LS_PPA